### PR TITLE
feat: Add allowed locations for resources in main.bicep

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -7,6 +7,7 @@ param environmentName string
 
 @minLength(1)
 @description('Primary location for all resources')
+@allowed(['uksouth','swedencentral', 'canadaeast', 'australiaeast'])
 param location string
 
 param resourceGroupName string = ''


### PR DESCRIPTION
This pull request includes a small but important change to the `infra/main.bicep` file. The change adds an `@allowed` attribute to the `location` parameter, specifying a list of allowed values for the location of the resources. This will enforce that only the locations 'uksouth', 'swedencentral', 'canadaeast', and 'australiaeast' can be used.

When deploying the resources with AZD, only the allowed regions are in the list.