### PR TITLE
Fix: Removed model_name and replaced usage with deployment_name

### DIFF
--- a/src-agents/phase3/notebook_p3.ipynb
+++ b/src-agents/phase3/notebook_p3.ipynb
@@ -48,8 +48,7 @@
     "    api_key = os.getenv(\"AZURE_OPENAI_API_KEY\"),\n",
     "    api_version = os.getenv(\"AZURE_OPENAI_VERSION\")\n",
     ")\n",
-    "deployment_name = os.getenv(\"AZURE_OPENAI_COMPLETION_DEPLOYMENT_NAME\")\n",
-    "model_name = os.getenv(\"AZURE_OPENAI_COMPLETION_MODEL\")"
+    "deployment_name = os.getenv(\"AZURE_OPENAI_COMPLETION_DEPLOYMENT_NAME\")"
    ]
   },
   {
@@ -287,7 +286,7 @@
     "            \n",
     "             # extend conversation with function response\n",
     "            second_response = client.chat.completions.create(\n",
-    "                model = model_name,\n",
+    "                model = deployment_name,\n",
     "                messages = messages)  # get a new response from the model where it can see the function response\n",
     "            \n",
     "            print(\"second_response\")\n",


### PR DESCRIPTION
This pull request includes changes to the `src-agents/phase3/notebook_p3.ipynb` file, specifically in the way the model is referenced in the OpenAI API calls. The changes remove the usage of a separate `model_name` variable and instead use the `deployment_name` variable for the model parameter in the API calls.

Changes:
* [`src-agents/phase3/notebook_p3.ipynb`](diffhunk://#diff-0e3b325dc84620322b3a2d4ef90e7252ae5c66076bfcb645984dc35604e91c00L51-R51): Removed the line where the `model_name` variable is defined. Now, `deployment_name` is used to specify the model in the OpenAI API calls.
* [`src-agents/phase3/notebook_p3.ipynb`](diffhunk://#diff-0e3b325dc84620322b3a2d4ef90e7252ae5c66076bfcb645984dc35604e91c00L290-R289): Replaced `model_name` with `deployment_name` in the `client.chat.completions.create` method call

The model_name variable is not available in ACA deployment for phase3. If the participants uses the example code with model_name it fails to run in ACA.