### PR TITLE
Update Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 ARG VARIANT=bullseye
-ARG VERSION=3.11
+ARG VERSION=3.12
 FROM mcr.microsoft.com/devcontainers/python:${VERSION}-${VARIANT}
 
 RUN export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 ARG VARIANT=bullseye
 ARG VERSION=3.11
-FROM --platform=amd64 mcr.microsoft.com/devcontainers/python:${VERSION}-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/python:${VERSION}-${VARIANT}
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \


### PR DESCRIPTION
This pull request updates the Python version used in the Dockerfile for the development container. The most important change is:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L2-R3): Updated the Python version from `3.11` to `3.12`.This pull request includes a minor update to the `.devcontainer/Dockerfile` to simplify the Docker image specification by removing the platform argument.

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L3-R3): Removed the `--platform=amd64` argument from the `FROM` statement.Changed from amd64 to universal