### PR TITLE
Fixed the initial PHASE1 request to ensure it processes correctly.

### DIFF
--- a/src-agents/phase1/main.py
+++ b/src-agents/phase1/main.py
@@ -57,11 +57,14 @@ async def ask_question(ask: Ask):
 
     # Send a completion call to generate an answer
     print('Sending a request to openai')
-    start_phrase =  ask.question
-    response: openai.types.chat.chat_completion.ChatCompletion = None
+    start_phrase = ask.question
+    response = client.chat.completions.create(
+        model = deployment_name,
+        messages = [{"role" : "assistant", "content" : start_phrase}],
+    )
 
-    # Send a completion call to generate an answer
-
+    print(response.choices[0].message.content)
+    print(response)
     answer = Answer(answer=response.choices[0].message.content)
     answer.correlationToken = ask.correlationToken
     answer.promptTokensUsed = response.usage.prompt_tokens


### PR DESCRIPTION
Problem & Reason for PR: 
The participants should test their setup in "Test the deployed resource". However, this currently fails with an internal server error. 

Autogenerated Notes:
This pull request includes a change to the `ask_question` function in the `src-agents/phase1/main.py` file to improve the way responses are handled from the OpenAI API.

Improvements to response handling:

* [`src-agents/phase1/main.py`](diffhunk://#diff-fe6068dd57908671d901b0233bd54d8b32dba08d14eee71c2d080d6c430a16faL61-R67): Replaced the placeholder response assignment with an actual call to `client.chat.completions.create` to generate an answer from the OpenAI API. Added print statements to display the response content and the entire response object for debugging purposes.